### PR TITLE
2.0.0 - Keep Case, More Keywords, Fix #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0
+* Case is now kept after reversing
+* Added more keywords
+* Fixed non-word-selections not being kept
+
 ## 1.1.0
 * Selection is now kept after reversing
 * Added more keywords

--- a/README.md
+++ b/README.md
@@ -2,19 +2,125 @@
 Reverses your current selections; e.g. false to true etc.
 
 ## List of reversible keywords
+### Boolean
 | Keyword 1 | Keyword 2 |
 |-----------|-----------|
-| true      | false     |
-| 0         | 1         |
-| x         | y         |
-| width     | height    |
+| and       | nand      |
+| or        | nor       |
+| false     | true      |
+| xnor      | xor       |
+
+### Brackets
+| Keyword 1 | Keyword 2 |
+|-----------|-----------|
 | (         | )         |
 | [         | ]         |
 | {         | }         |
-| +         | -         |
+| <         | >         |
+
+### Events
+| Keyword 1    | Keyword 2    |
+|--------------|--------------|
+| audioEnd     | audioStart   |
+| blur         | focus        |
+| drag         | drop         |
+| dragEnter    | dragLeave    |
+| keyDown      | keyUp        |
+| mouseDown    | mouseUp      |
+| mouseEnter   | mouseLeave   |
+| mouseOut     | mouseOver    |
+| onMouseDown  | onMouseUp    |
+| onMouseEnter | onMouseLeave |
+| onMouseOut   | onMouseOver  |
+| pageHide     | pageShow     |
+| speechEnd    | speechStart  |
+| touchEnd     | touchStart   |
+
+### HTML
+| Keyword 1 | Keyword 2 |
+|-----------|-----------|
+| big       | small     |
+| body      | head      |
+| del       | ins       |
+| footer    | header    |
+| noScript  | script    |
+| ol        | ul        |
+| tFoot     | tHead     |
+
+### Math
+| Keyword 1 | Keyword 2  |
+|-----------|------------|
+| atan      | tan        |
+| cos       | sin        |
+| ceil      | floor      |
+| Math.atan | Math.tan   |
+| Math.ceil | Math.floor |
+| Math.cos  | Math.sin   |
+| Math.exp  | Math.log   |
+| Math.max  | Math.min   |
+| max       | min        |
+
+### Network
+| Keyword 1 | Keyword 2  |
+|-----------|------------|
+| client    | server     |
+| connect   | disconnect |
+| offline   | online     |
+
+### Operators
+| Keyword 1 | Keyword 2 |
+|-----------|-----------|
 | *         | /         |
-| up        | down      |
+| *=        | /=        |
+| &         | |         |
+| &&        | ||        |
+| &=        | |=        |
+| +         | -         |
+| ++        | --        |
+| +=        | -=        |
+| <<        | >>        |
+| <<=       | >>=       |
+| <=        | >=        |
+| ==        | !=        |
+| ===       | !==       |
+
+### Positions
+| Keyword 1 | Keyword 2 |
+|-----------|-----------|
+| bottom    | top       |
+| down      | up        |
 | left      | right     |
-| top       | bottom    |
-| hidden    | visible   |
+
+### Single Characters
+| Keyword 1 | Keyword 2 |
+|-----------|-----------|
 | '         | "         |
+| 0         | 1         |
+| x         | y         |
+
+### Other
+| Keyword 1   | Keyword 2  |
+|-------------|------------|
+| activate    | deactivate |
+| add         | remove     |
+| after       | before     |
+| background  | foreground |
+| column      | row        |
+| delete      | insert     |
+| destination | source     |
+| enabled     | disabled   |
+| height      | width      |
+| hidden      | visible    |
+| hide        | show       |
+| import      | export     |
+| imports     | exports    |
+| in          | out        |
+| input       | output     |
+| key         | value      |
+| load        | unload     |
+| next        | previous   |
+| open        | close      |
+| over        | under      |
+| pause       | resume     |
+| private     | public     |
+| that        | this       |

--- a/lib/atom-reverser.coffee
+++ b/lib/atom-reverser.coffee
@@ -3,36 +3,107 @@
 module.exports = AtomReverser =
     subscriptions: null
     keywords:
-        "true": "false"
+        # boolean
+        "and": "nand"
+        "or": "nor"
         "false": "true"
-        "1": "0"
-        "0": "1"
-        "x": "y"
-        "y": "x"
-        "width": "height"
-        "height": "width"
+        "xnor": "xor"
+        # brackets
         "(": ")"
-        ")": "("
         "[": "]"
-        "]": "["
         "{": "}"
-        "}": "{"
-        "+": "-"
-        "-": "+"
+        "<": ">"
+        # events
+        "audioEnd": "audioStart"
+        "blur": "focus"
+        "drag": "drop"
+        "dragEnter": "dragLeave"
+        "keyDown": "keyUp"
+        "mouseDown": "mouseUp"
+        "mouseEnter": "mouseLeave"
+        "mouseOut": "mouseOver"
+        "onMouseDown": "onMouseUp"
+        "onMouseEnter": "onMouseLeave"
+        "onMouseOut": "onMouseOver"
+        "pageHide": "pageShow"
+        "speechEnd": "speechStart"
+        "touchEnd": "touchStart"
+        # html
+        "big": "small"
+        "body": "head"
+        "del": "ins"
+        "footer": "header"
+        "noScript": "script"
+        "ol": "ul"
+        "tFoot": "tHead"
+        # math
+        "atan": "tan"
+        "cos": "sin"
+        "ceil": "floor"
+        "Math.atan": "Math.tan"
+        "Math.ceil": "Math.floor"
+        "Math.cos": "Math.sin"
+        "Math.exp": "Math.log"
+        "Math.max": "Math.min"
+        "max": "min"
+        # network
+        "client": "server"
+        "connect": "disconnect"
+        "offline": "online"
+        # operators
         "*": "/"
-        "/": "*"
-        "up": "down"
+        "*=": "/="
+        "&": "|"
+        "&&": "||"
+        "&=": "|="
+        "+": "-"
+        "++": "--"
+        "+=": "-="
+        "<<": ">>"
+        "<<=": ">>="
+        "<=": ">="
+        "==": "!="
+        "===": "!=="
+        # positions
+        "bottom": "top"
         "down": "up"
         "left": "right"
-        "right": "left"
-        "top": "bottom"
-        "bottom": "top"
-        "hidden": "visible"
-        "visible": "hidden"
+        # react
+        "addChangeListener": "removeChangeListener"
+        "componentDidMount": "componentWillUnmount"
+        # single characters
         "'": "\""
-        "\"": "'"
+        "0": "1"
+        "x": "y"
+        # other
+        "activate": "deactivate"
+        "add": "remove"
+        "after": "before"
+        "background": "foreground"
+        "column": "row"
+        "delete": "insert"
+        "destination": "source"
+        "enabled": "disabled"
+        "height": "width"
+        "hidden": "visible"
+        "hide": "show"
+        "import": "export"
+        "imports": "exports"
+        "in": "out"
+        "input": "output"
+        "key": "value"
+        "load": "unload"
+        "next": "previous"
+        "open": "close"
+        "over": "under"
+        "pause": "resume"
+        "private": "public"
+        "that": "this"
 
     activate: (state) ->
+        # Also add reversed keywords
+        @keywords[value] = key for key, value of @keywords
+
         # Register command that toggles this view
         @subscriptions = new CompositeDisposable
         @subscriptions.add atom.commands.add 'atom-workspace',
@@ -45,35 +116,57 @@ module.exports = AtomReverser =
         atom.workspace.getActiveTextEditor()
 
     invertString: (string) ->
-        if @keywords[string] != undefined
-            return @keywords[string]
+        for key, value of @keywords
+            if key.toLowerCase() == string
+                return value
 
         return false
+
+    detectCase: (string) ->
+        currentCase = 'unknown';
+        if string.toLowerCase() == string
+            currentCase = 'lowercase'
+        else if string.toUpperCase() == string
+            currentCase = 'UPPERCASE'
+        else if string[0].toLowerCase() == string[0]
+            currentCase = 'camelCase'
+        else if string[0].toUpperCase() == string[0]
+            currentCase = 'TitleCase'
+        return currentCase
+
+    applyCase: (string, toCase) ->
+        return string if string == false
+        switch toCase
+            when "lowercase"
+                return string.toLowerCase()
+            when "UPPERCASE"
+                return string.toUpperCase()
+            when "camelCase"
+                return string
+            when "TitleCase"
+                return string[0].toUpperCase() + string.substring(1)
+            else
+                return string
 
     reverse: ->
         editor = @getActiveEditor()
         return unless editor
-
 
         selections = editor.getSelections()
 
         for selection in selections
             do (selection) ->
             text = selection.getText()
+
             # If nothing is selected select the current word
             if text == ""
                 selection.selectWord()
                 text = selection.getText()
 
-
-            # TODO: Save the current casing to restore it afterwards
+            # Save the current casing to restore it afterwards
+            currentCase = @detectCase(text)
             text = text.toLowerCase()
-            replacementText = @invertString(text)
+            replacementText = @applyCase(@invertString(text), currentCase)
 
             if replacementText
-                selection.insertText(replacementText)
-
-            # Keep selections
-            selection.selectWord()
-
-            #TODO: Format the text using the correct casing
+                selection.insertText(replacementText, {select: true})

--- a/menus/atom-reverser.cson
+++ b/menus/atom-reverser.cson
@@ -10,7 +10,7 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'atom-reverser'
+      'label': 'Reverser'
       'submenu': [
         {
           'label': 'Reverse'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-reverser",
   "main": "./lib/atom-reverser",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Reverses your current selection; e.g. false to true etc.",
   "keywords": [],
   "activationCommands": {


### PR DESCRIPTION
### Changes:
- Attempts to keep the selection's case (supports lowercase, UPPERCASE, camelCase and TitleCase)
- Far More Keywords (now sorted & categorized & Word 1 < Word 2)
- You no longer have to type `a -> b & b -> a` to add new keywords.
- Fix #3
### Questions you might have:
- Why did I decide to invert `&` to `|`?
  - They're the most frequently used boolean operators (besides not) and often have to be converted into each other.
- How are the keywords ordered?
  1. By Category
  2. Internally Keyword 1 always comes before Keyword 2 (a -> b instead of b -> a)
  3. By `atom/sort-lines`
- Why did I decide to bump to 2.0.0?
  - Keeping the selection-case is a breaking-change compared to version 1.0.0.
  - I assume you use semantic Versioning for this project.
